### PR TITLE
Add logger gem for Ruby 4.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,4 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem "webrick"
 gem "csv"
 gem "base64"
+gem "logger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
@@ -86,6 +87,7 @@ DEPENDENCIES
   jekyll
   jekyll-compose
   jekyll-feed (~> 0.6)
+  logger
   minima (~> 2.5.0)
   tzinfo-data
   webrick


### PR DESCRIPTION
## Summary

- `logger` was extracted from the Ruby standard library in 3.4 and is no longer a default gem in 4.0
- Jekyll 4.3.3 requires it at startup, causing the `cannot load such file -- logger (LoadError)` build failure
- Adds `logger` to the Gemfile and regenerates the lockfile against Ruby 4.0.1