### PR TITLE
Add devcontainer for Jekyll + automated resume PDF generation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+# Match .ruby-version so the container build matches CI / GitHub Pages.
+FROM ruby:4.0.1-bookworm
+
+# Chromium drives the headless render of assets/resume.pdf. The two font
+# packages are metric-compatible stand-ins for Calibri and Arial, which Linux
+# doesn't ship, so the resume PDF still renders with its intended typeface:
+#   - fonts-crosextra-carlito -> drop-in for "Calibri" (installs a fontconfig
+#     alias, so the CSS font-family "Calibri" resolves to Carlito automatically)
+#   - fonts-liberation        -> drop-in for Arial / Helvetica
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      chromium \
+      fonts-crosextra-carlito \
+      fonts-liberation \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Portable handle for the headless browser, referenced by CLAUDE.md and the
+# build instructions in assets/resume.md. Use this instead of a hard-coded path.
+ENV CHROME_BIN=/usr/bin/chromium

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "breckenridge.dev (Jekyll + resume PDF)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "vscode",
+      "userUid": "automatic",
+      "userGid": "automatic",
+      "installZsh": false
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "remoteUser": "vscode",
+  "forwardPorts": [4000],
+  "postCreateCommand": "sh .devcontainer/setup-ssh.sh && bundle install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-lsp"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "breckenridge.dev (Jekyll + resume PDF)",
+  "name": "breckenridge.dev",
   "build": {
     "dockerfile": "Dockerfile"
   },

--- a/.devcontainer/setup-ssh.sh
+++ b/.devcontainer/setup-ssh.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# SSH setup for the devcontainer.
+#
+# The VS Code Dev Containers extension forwards the host's SSH *agent* into the
+# container automatically (SSH_AUTH_SOCK is already set), on any host OS, so
+# private keys never enter the container and you do NOT bind-mount ~/.ssh.
+# (Bind-mounting is also outright broken on Windows hosts: Docker mounts the
+# path 0777 and OpenSSH refuses world-writable keys. See issue #33.)
+#
+# So there's almost nothing to do here. This script just makes ~/.ssh sane and
+# pre-trusts github.com so the first git push doesn't hang on a prompt. It is
+# idempotent and safe to re-run on every rebuild.
+set -e
+
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+
+if [ ! -f "$HOME/.ssh/known_hosts" ] || ! grep -q "github.com" "$HOME/.ssh/known_hosts" 2>/dev/null; then
+  ssh-keyscan github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true
+  chmod 644 "$HOME/.ssh/known_hosts"
+fi
+
+# Sanity check (non-fatal): show whether the forwarded agent has any identities.
+if [ -n "$SSH_AUTH_SOCK" ]; then
+  ssh-add -l >/dev/null 2>&1 \
+    && echo "SSH agent forwarded with identities available." \
+    || echo "SSH agent forwarded but no identities loaded yet (run 'ssh-add' on the host)."
+else
+  echo "No SSH agent forwarded (SSH_AUTH_SOCK unset) - git over SSH may not work."
+fi

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts and the Dockerfile run inside the Linux devcontainer, so they
+# must keep LF endings regardless of the host checkout settings (CRLF breaks
+# the shebang in the container: "/bin/sh^M: bad interpreter").
+*.sh            text eol=lf
+.devcontainer/Dockerfile text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+Guidance for agents working in this repo: Aaron Breckenridge's personal blog +
+resume site, a Jekyll / GitHub Pages site served at www.breckenridge.dev
+(minima theme, kramdown markdown, custom domain via `CNAME`).
+
+## Development environment
+
+This repo ships a devcontainer (`.devcontainer/`) so the full toolchain is
+available without installing anything on the host. Open the folder in VS Code
+and "Reopen in Container", or run `devcontainer up` from the CLI. It provides:
+
+- **Ruby** (pinned by `.ruby-version`) with Bundler for the Jekyll build.
+- **Chromium** at `$CHROME_BIN` (`/usr/bin/chromium`) for rendering the resume
+  PDF. Use this env var instead of a hard-coded browser path.
+- **Carlito + Liberation fonts**: metric-compatible stand-ins for Calibri and
+  Arial (which Linux doesn't ship), so `assets/resume.pdf` renders with its
+  intended typeface.
+- **GitHub CLI** plus **SSH agent forwarding**. VS Code forwards the host SSH
+  agent into the container automatically on any host OS; do not bind-mount
+  `~/.ssh`. See issue #33 for the (Windows-specific) permission gotcha.
+
+## Common tasks
+
+Serve the site locally (port 4000 is forwarded):
+
+```sh
+bundle exec jekyll serve
+```
+
+Create a new post:
+
+```sh
+bundle exec rake new_post["My Title"]
+```
+
+## Regenerating the resume PDF
+
+`assets/resume.md` is the single source of truth for the resume content; the
+full styling/build conventions live in its YAML frontmatter. The published
+artifact is `assets/resume.pdf`, embedded by the `/resume` page via an iframe.
+`assets/resume.md` itself is excluded from the Jekyll build (see `_config.yml`),
+so it lives in the repo as source only and is never served.
+
+After editing the content:
+
+1. Build the styled standalone HTML (`assets/resume.html`) per the conventions
+   documented in the frontmatter of `assets/resume.md`.
+2. Render it to PDF with headless Chromium. Inside the devcontainer the browser
+   is portable via `$CHROME_BIN`, and a fresh `--user-data-dir` is required so
+   Chromium starts its own instance instead of attaching to a running one
+   (otherwise the PDF is silently not written):
+
+   ```sh
+   "$CHROME_BIN" --headless=new --disable-gpu --no-first-run \
+     --no-default-browser-check --user-data-dir="$(mktemp -d)" \
+     --no-pdf-header-footer --run-all-compositor-stages-before-draw \
+     --virtual-time-budget=8000 \
+     --print-to-pdf="assets/resume.pdf" \
+     "file://$(pwd)/assets/resume.html"
+   ```
+
+3. Verify the PDF visually (2 pages, black, ragged-right) and commit it
+   alongside the source. The `/resume` page needs no changes.
+
+Outside the container, substitute your local browser path (example paths are
+documented in the frontmatter of `assets/resume.md`).

--- a/assets/resume.md
+++ b/assets/resume.md
@@ -43,10 +43,11 @@
 #              --print-to-pdf="assets/resume.pdf" \
 #              "file:///<absolute-path>/assets/resume.html"
 #
-#          Chrome on this machine:
+#          Inside the repo devcontainer, use the portable handle $CHROME_BIN
+#          (/usr/bin/chromium). See CLAUDE.md. Outside the container, point at a
+#          local browser, e.g. on Windows:
 #            C:\Program Files\Google\Chrome\Application\chrome.exe
-#          (Edge works as a fallback:
-#            C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe)
+#            C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe
 #
 # Step 3 — Verify the PDF visually (2 pages, black, ragged-right) and keep it in
 #          sync with this file. The /resume page needs no changes; it always


### PR DESCRIPTION
Adds a `.devcontainer/` so the site builds and the resume PDF regenerates from a consistent, host-agnostic toolchain (no host installs).

## What it provides
- **Ruby 4.0.1** (matches `.ruby-version`) + Bundler for the Jekyll build.
- **Chromium** for the headless `assets/resume.pdf` render, exposed as `$CHROME_BIN` so build instructions drop the hard-coded browser path.
- **Carlito + Liberation fonts** as metric-compatible stand-ins for Calibri/Arial (which Linux lacks), so the PDF keeps its intended typeface.
- **GitHub CLI** and **SSH agent forwarding** (host agent forwarded automatically on any OS; no bind-mounted `~/.ssh`), following the approach in issue #33.
- Forwards port 4000 for `jekyll serve`; runs `setup-ssh.sh` + `bundle install` on create.

## Docs
- **CLAUDE.md** (new): documents the devcontainer, common tasks, and the portable Chromium command for regenerating the resume PDF.
- **assets/resume.md**: build-instruction frontmatter now points at `$CHROME_BIN` in the container, with local browser paths as the out-of-container fallback.
- **.gitattributes**: forces LF on shell scripts + Dockerfile so the shebang works in the Linux container.
@